### PR TITLE
Update to atlassian-connect-play 0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/toolsplus/atlassian-connect-play-slick.svg?branch=master)](https://travis-ci.org/toolsplus/atlassian-connect-play-slick)
 [![codecov](https://codecov.io/gh/toolsplus/atlassian-connect-play-slick/branch/master/graph/badge.svg)](https://codecov.io/gh/toolsplus/atlassian-connect-play-slick)
-[![Maven Central](https://img.shields.io/maven-central/v/io.toolsplus/atlassian-connect-play-slick_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/io.toolsplus/atlassian-connect-play-slick_2.11)
+[![Maven Central](https://img.shields.io/maven-central/v/io.toolsplus/atlassian-connect-play-slick_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/io.toolsplus/atlassian-connect-play-slick_2.12)
 
 Atlassian Connect Play Slick is a Play module providing Slick 
 implementation for data repositories defined in [Atlassian Connect Play](atlassian-connect-play).
@@ -12,7 +12,7 @@ implementation for data repositories defined in [Atlassian Connect Play](atlassi
 atlassian-connect-play-slick is published to Maven Central for Scala 2.12 and 
 Play 2.6.x, so you can just add the following to your build:
 
-    libraryDependencies += "io.toolsplus" %% "atlassian-connect-play-slick" % 0.1.1
+    libraryDependencies += "io.toolsplus" %% "atlassian-connect-play-slick" % 0.1.2
 
 ### JDBC driver dependency
 The Play Slick module does not bundle any JDBC driver. Hence, you will need to 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ReleaseTransformations._
 
 val commonSettings = Seq(
   organization := "io.toolsplus",
-  scalaVersion := "2.12.4"
+  scalaVersion := "2.12.6"
 )
 
 lazy val publishSettings = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,8 +12,8 @@ object Dependencies {
 }
 
 object Version {
-  val atlassianConnectPlay = "0.1.2"
-  val playSlick = "3.0.2"
+  val atlassianConnectPlay = "0.1.6"
+  val playSlick = "3.0.3"
   val scalaTestPlusPlay = "3.1.2"
   val scalaCheck = "1.13.5"
   val h2 = "1.4.196"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.3
+sbt.version = 1.1.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.3.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/src/main/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepository.scala
+++ b/src/main/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepository.scala
@@ -1,8 +1,10 @@
 package io.toolsplus.atlassian.connect.play.slick
 
 import javax.inject.{Inject, Singleton}
-
-import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
+import io.toolsplus.atlassian.connect.play.api.models.{
+  AtlassianHost,
+  StandardAtlassianHost
+}
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
@@ -84,7 +86,50 @@ private[slick] trait AtlassianHostTable {
        productType,
        description,
        serviceEntitlementNumber,
-       installed) <> ((AtlassianHost.apply _).tupled, AtlassianHost.unapply)
+       installed) <> (toHost.tupled, fromHost)
+
+    private def toHost: (ClientKey,
+                         String,
+                         String,
+                         Option[String],
+                         String,
+                         String,
+                         String,
+                         String,
+                         String,
+                         String,
+                         Option[String],
+                         Boolean) => AtlassianHost = StandardAtlassianHost.apply
+  }
+
+  private def fromHost: AtlassianHost => Option[
+    (ClientKey,
+     String,
+     String,
+     Option[String],
+     String,
+     String,
+     String,
+     String,
+     String,
+     String,
+     Option[String],
+     Boolean)] = { host: AtlassianHost =>
+    StandardAtlassianHost.unapply(
+      StandardAtlassianHost(
+        host.clientKey,
+        host.key,
+        host.publicKey,
+        host.oauthClientId,
+        host.sharedSecret,
+        host.serverVersion,
+        host.pluginsVersion,
+        host.baseUrl,
+        host.productType,
+        host.description,
+        host.serviceEntitlementNumber,
+        host.installed
+      ))
   }
 
 }

--- a/src/test/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
+++ b/src/test/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
@@ -1,10 +1,10 @@
 package io.toolsplus.atlassian.connect.play.slick.fixtures
 
-import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
+import io.toolsplus.atlassian.connect.play.api.models.StandardAtlassianHost
 import io.toolsplus.atlassian.connect.play.slick.generators.AtlassianHostGen
 
 trait AtlassianHostFixture extends AtlassianHostGen {
-  val defaultHost = AtlassianHost(
+  val defaultHost = StandardAtlassianHost(
     "a890cfe7-3518-3920-b0b5-6fa412a7f3d4",
     "io.toolsplus.atlassian.connect.play.scala.seed",
     "MIGfMA0GCSqGDc10pQ4Xo+l/BaWhmiHXDDQ/tOjgfqaDxiXuIi/Jhk4D73aHbL9FwIDAQAB",

--- a/src/test/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
+++ b/src/test/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
@@ -1,10 +1,9 @@
 package io.toolsplus.atlassian.connect.play.slick.generators
 
-import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
+import io.toolsplus.atlassian.connect.play.api.models.StandardAtlassianHost
 import org.scalacheck.Gen
-import org.scalacheck.Gen._
-import org.scalacheck.Gen.{alphaStr, numStr, option}
+import org.scalacheck.Gen.{alphaStr, numStr, option, _}
 
 trait AtlassianHostGen {
 
@@ -15,7 +14,7 @@ trait AtlassianHostGen {
 
   def productTypeGen: Gen[String] = oneOf("jira", "confluence")
 
-  def atlassianHostGen: Gen[AtlassianHost] =
+  def atlassianHostGen: Gen[StandardAtlassianHost] =
     for {
       key <- alphaStr
       clientKey <- clientKeyGen
@@ -30,17 +29,17 @@ trait AtlassianHostGen {
       serviceEntitlementNumber <- option(numStr)
       installed <- oneOf(true, false)
     } yield
-      AtlassianHost(clientKey,
-                    key,
-                    publicKey,
-                    oauthClientId,
-                    sharedSecret,
-                    serverVersion,
-                    pluginsVersion,
-                    baseUrl,
-                    productType,
-                    description,
-                    serviceEntitlementNumber,
-                    installed)
+      StandardAtlassianHost(clientKey,
+                            key,
+                            publicKey,
+                            oauthClientId,
+                            sharedSecret,
+                            serverVersion,
+                            pluginsVersion,
+                            baseUrl,
+                            productType,
+                            description,
+                            serviceEntitlementNumber,
+                            installed)
 
 }


### PR DESCRIPTION
- Update atlassian-connect-play to version 0.1.6
- Change AtlassianHost and AtlassianHostUser to their standard case class implementations
- Update dependencies and to Scala 2.12.6