### PR TITLE
Update repository with new fields and remove deprecated fields

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
 }
 
 object Version {
-  val atlassianConnectPlay = "0.4.2"
+  val atlassianConnectPlay = "0.5.0"
   val playSlick = "5.1.0"
   val scalaTestPlusPlay = "5.1.0"
   val scalaCheck = "1.14.3"

--- a/src/it/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepositoryIt.scala
+++ b/src/it/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepositoryIt.scala
@@ -68,12 +68,6 @@ class SlickAtlassianHostRepositoryIt
         } mustBe None
       }
 
-      "return None when trying to find a non existent host by baseUrl" in {
-        await {
-          hostRepo.findByBaseUrl("fake-base-url")
-        } mustBe None
-      }
-
     }
 
     "saving a Atlassian hosts to the repository" should {
@@ -98,18 +92,6 @@ class SlickAtlassianHostRepositoryIt
 
           await {
             hostRepo.findByClientKey(host.clientKey)
-          } mustBe Some(host)
-        }
-      }
-
-      "find the inserted host by base URL" in new AtlassianHostFixture {
-        withEvolutions {
-          await {
-            hostRepo.save(host)
-          } mustBe host
-
-          await {
-            hostRepo.findByBaseUrl(host.baseUrl)
           } mustBe Some(host)
         }
       }

--- a/src/it/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
+++ b/src/it/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
@@ -4,19 +4,20 @@ import io.toolsplus.atlassian.connect.play.api.models.DefaultAtlassianHost
 import io.toolsplus.atlassian.connect.play.slick.generators.AtlassianHostGen
 
 trait AtlassianHostFixture extends AtlassianHostGen {
-  val defaultHost = DefaultAtlassianHost(
+  val defaultHost: DefaultAtlassianHost = DefaultAtlassianHost(
     "a890cfe7-3518-3920-b0b5-6fa412a7f3d4",
     "io.toolsplus.atlassian.connect.play.scala.seed",
-    "MIGfMA0GCSqGDc10pQ4Xo+l/BaWhmiHXDDQ/tOjgfqaDxiXuIi/Jhk4D73aHbL9FwIDAQAB",
     None,
     "LkbauUXN71J8jxRi9Nbf+8dwGtXxqta+Fu6k86aF+0IIzxkZ/GlggElYVoCqQg",
-    "100035",
-    "1.2.35",
+    "https://example.atlassian.net",
+    "https://example.atlassian.net",
     "https://example.atlassian.net",
     "jira",
     "Atlassian JIRA at https://example.atlassian.net",
     None,
+    None,
+    None,
     installed = true
   )
-  val host = atlassianHostGen.sample.getOrElse(defaultHost)
+  val host: DefaultAtlassianHost = atlassianHostGen.sample.getOrElse(defaultHost)
 }

--- a/src/it/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
+++ b/src/it/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
@@ -9,37 +9,36 @@ trait AtlassianHostGen {
 
   def clientKeyGen: Gen[ClientKey] = alphaNumStr
 
-  def pluginVersionGen: Gen[String] =
-    listOfN(3, posNum[Int]).map(n => n.mkString("."))
-
   def productTypeGen: Gen[String] = oneOf("jira", "confluence")
 
   def atlassianHostGen: Gen[DefaultAtlassianHost] =
     for {
       key <- alphaStr
       clientKey <- clientKeyGen
-      publicKey <- alphaNumStr
       oauthClientId <- option(alphaNumStr)
-      sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && !s.isEmpty)
-      serverVersion <- numStr
-      pluginsVersion <- pluginVersionGen
+      sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && s.nonEmpty)
       baseUrl <- alphaStr
       productType <- productTypeGen
       description <- alphaStr
       serviceEntitlementNumber <- option(numStr)
+      entitlementId <- option(numStr)
+      entitlementNumber <- option(numStr)
       installed <- oneOf(true, false)
     } yield
-      DefaultAtlassianHost(clientKey,
-                            key,
-                            publicKey,
-                            oauthClientId,
-                            sharedSecret,
-                            serverVersion,
-                            pluginsVersion,
-                            baseUrl,
-                            productType,
-                            description,
-                            serviceEntitlementNumber,
-                            installed)
+      DefaultAtlassianHost(
+        clientKey,
+        key,
+        oauthClientId,
+        sharedSecret,
+        baseUrl,
+        baseUrl,
+        baseUrl,
+        productType,
+        description,
+        serviceEntitlementNumber,
+        entitlementId,
+        entitlementNumber,
+        installed
+      )
 
 }

--- a/src/main/resources/evolutions/default/1.sql
+++ b/src/main/resources/evolutions/default/1.sql
@@ -1,22 +1,24 @@
 # --- !Ups
-CREATE TABLE atlassian_host (
-  client_key                 VARCHAR PRIMARY KEY           NOT NULL,
-  key                        VARCHAR                       NOT NULL,
-  public_key                 VARCHAR                       NOT NULL,
-  oauth_client_id            VARCHAR,
-  shared_secret              VARCHAR                       NOT NULL,
-  server_version             VARCHAR                       NOT NULL,
-  plugins_version            VARCHAR                       NOT NULL,
-  base_url                   VARCHAR                       NOT NULL,
-  product_type               VARCHAR                       NOT NULL,
-  description                VARCHAR                       NOT NULL,
-  service_entitlement_number VARCHAR,
-  installed                  VARCHAR                       NOT NULL
+CREATE TABLE atlassian_host
+(
+    client_key                          VARCHAR PRIMARY KEY NOT NULL,
+    key                                 VARCHAR             NOT NULL,
+    oauth_client_id                     VARCHAR,
+    shared_secret                       VARCHAR             NOT NULL,
+    base_url                            VARCHAR             NOT NULL,
+    display_url                         VARCHAR             NOT NULL,
+    display_url_servicedesk_help_center VARCHAR             NOT NULL,
+    product_type                        VARCHAR             NOT NULL,
+    description                         VARCHAR             NOT NULL,
+    service_entitlement_number          VARCHAR,
+    entitlement_id                      VARCHAR,
+    entitlement_number                  VARCHAR,
+    installed                           VARCHAR             NOT NULL
 );
 CREATE UNIQUE INDEX uq_ac_host_client_key
-  ON atlassian_host (client_key);
+    ON atlassian_host (client_key);
 CREATE INDEX uq_ac_host_base_url
-  ON atlassian_host (base_url);
+    ON atlassian_host (base_url);
 
 # --- !Downs
 DROP TABLE atlassian_host;

--- a/src/main/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepository.scala
+++ b/src/main/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepository.scala
@@ -28,9 +28,6 @@ class SlickAtlassianHostRepository @Inject()(
   def findByClientKey(clientKey: ClientKey): Future[Option[AtlassianHost]] =
     db.run(hosts.filter(_.clientKey === clientKey).result.headOption)
 
-  def findByBaseUrl(baseUrl: String): Future[Option[AtlassianHost]] =
-    db.run(hosts.filter(_.baseUrl === baseUrl).result.headOption)
-
   /** Saves the given Atlassian host by inserting it if it does not exist or
     * updating an existing record if it's already present.
     *
@@ -57,17 +54,23 @@ private[slick] trait AtlassianHostTable {
       extends Table[AtlassianHost](tag, "atlassian_host") {
     val clientKey = column[ClientKey]("client_key", O.PrimaryKey)
     val key = column[String]("key", NotNull)
-    val publicKey =
-      column[String]("public_key", NotNull, SqlType("VARCHAR(512)"))
     val oauthClientId = column[Option[String]]("oauth_client_id")
     val sharedSecret = column[String]("shared_secret", NotNull)
-    val serverVersion = column[String]("server_version", NotNull)
-    val pluginsVersion = column[String]("plugins_version", NotNull)
     val baseUrl = column[String]("base_url", NotNull, SqlType("VARCHAR(512)"))
+    val displayUrl =
+      column[String]("display_url", NotNull, SqlType("VARCHAR(512)"))
+    val displayUrlServicedeskHelpCenter = column[String](
+      "display_url_servicedesk_help_center",
+      NotNull,
+      SqlType("VARCHAR(512)"))
     val productType = column[String]("product_type", NotNull)
     val description = column[String]("description", NotNull)
     val serviceEntitlementNumber =
       column[Option[String]]("service_entitlement_number")
+    val entitlementId =
+      column[Option[String]]("entitlement_id")
+    val entitlementNumber =
+      column[Option[String]]("entitlement_number")
     val installed = column[Boolean]("installed", NotNull)
 
     val clientKeyIndex =
@@ -77,19 +80,19 @@ private[slick] trait AtlassianHostTable {
     def * =
       (clientKey,
        key,
-       publicKey,
        oauthClientId,
        sharedSecret,
-       serverVersion,
-       pluginsVersion,
        baseUrl,
+       displayUrl,
+       displayUrlServicedeskHelpCenter,
        productType,
        description,
        serviceEntitlementNumber,
+       entitlementId,
+       entitlementNumber,
        installed) <> (toHost.tupled, fromHost)
 
     private def toHost: (ClientKey,
-                         String,
                          String,
                          Option[String],
                          String,
@@ -98,6 +101,8 @@ private[slick] trait AtlassianHostTable {
                          String,
                          String,
                          String,
+                         Option[String],
+                         Option[String],
                          Option[String],
                          Boolean) => AtlassianHost = DefaultAtlassianHost.apply
   }
@@ -105,7 +110,6 @@ private[slick] trait AtlassianHostTable {
   private def fromHost: AtlassianHost => Option[
     (ClientKey,
      String,
-     String,
      Option[String],
      String,
      String,
@@ -113,21 +117,24 @@ private[slick] trait AtlassianHostTable {
      String,
      String,
      String,
+     Option[String],
+     Option[String],
      Option[String],
      Boolean)] = { host: AtlassianHost =>
     DefaultAtlassianHost.unapply(
       DefaultAtlassianHost(
         host.clientKey,
         host.key,
-        host.publicKey,
         host.oauthClientId,
         host.sharedSecret,
-        host.serverVersion,
-        host.pluginsVersion,
         host.baseUrl,
+        host.displayUrl,
+        host.displayUrlServicedeskHelpCenter,
         host.productType,
         host.description,
         host.serviceEntitlementNumber,
+        host.entitlementId,
+        host.entitlementNumber,
         host.installed
       ))
   }

--- a/src/test/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepositorySpec.scala
+++ b/src/test/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepositorySpec.scala
@@ -12,22 +12,22 @@ class SlickAtlassianHostRepositorySpec
     extends TestSpec
     with GuiceOneAppPerTest {
 
-  override def fakeApplication() = {
+  override def fakeApplication(): Application = {
     val config = TestData.configuration
     GuiceApplicationBuilder(configuration = config).build()
   }
 
-  def withEvolutions[T](block: => T) =
+  def withEvolutions[T](block: => T): T =
     Evolutions.withEvolutions(
       dbApi.database("default"),
       ClassLoaderEvolutionsReader.forPrefix("evolutions/")) {
       block
     }
 
-  def dbApi(implicit app: Application) =
+  def dbApi(implicit app: Application): DBApi =
     Application.instanceCache[DBApi].apply(app)
 
-  def hostRepo(implicit app: Application) =
+  def hostRepo(implicit app: Application): SlickAtlassianHostRepository =
     Application.instanceCache[SlickAtlassianHostRepository].apply(app)
 
   "Using a Slick host repository" when {
@@ -44,14 +44,6 @@ class SlickAtlassianHostRepositorySpec
         forAll(alphaStr) { clientKey =>
           await {
             hostRepo.findByClientKey(clientKey)
-          } mustBe None
-        }
-      }
-
-      "return None when trying to find a non existent host by baseUrl" in {
-        forAll(alphaStr) { baseUrl =>
-          await {
-            hostRepo.findByBaseUrl(baseUrl)
           } mustBe None
         }
       }
@@ -83,19 +75,6 @@ class SlickAtlassianHostRepositorySpec
           } mustBe Some(host)
         }
       }
-
-      "find the inserted host by base URL" in new AtlassianHostFixture {
-        withEvolutions {
-          await {
-            hostRepo.save(host)
-          } mustBe host
-
-          await {
-            hostRepo.findByBaseUrl(host.baseUrl)
-          } mustBe Some(host)
-        }
-      }
-
     }
 
     "saving the same Atlassian hosts twice" should {

--- a/src/test/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
+++ b/src/test/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
@@ -1,22 +1,23 @@
 package io.toolsplus.atlassian.connect.play.slick.fixtures
 
-import io.toolsplus.atlassian.connect.play.api.models.DefaultAtlassianHost
+import io.toolsplus.atlassian.connect.play.api.models.{AtlassianHost, DefaultAtlassianHost}
 import io.toolsplus.atlassian.connect.play.slick.generators.AtlassianHostGen
 
 trait AtlassianHostFixture extends AtlassianHostGen {
-  val defaultHost = DefaultAtlassianHost(
+  val defaultHost: DefaultAtlassianHost = DefaultAtlassianHost(
     "a890cfe7-3518-3920-b0b5-6fa412a7f3d4",
     "io.toolsplus.atlassian.connect.play.scala.seed",
-    "MIGfMA0GCSqGDc10pQ4Xo+l/BaWhmiHXDDQ/tOjgfqaDxiXuIi/Jhk4D73aHbL9FwIDAQAB",
     None,
     "LkbauUXN71J8jxRi9Nbf+8dwGtXxqta+Fu6k86aF+0IIzxkZ/GlggElYVoCqQg",
-    "100035",
-    "1.2.35",
+    "https://example.atlassian.net",
+    "https://example.atlassian.net",
     "https://example.atlassian.net",
     "jira",
     "Atlassian JIRA at https://example.atlassian.net",
     None,
+    None,
+    None,
     installed = true
   )
-  val host = atlassianHostGen.sample.getOrElse(defaultHost)
+  val host: DefaultAtlassianHost = atlassianHostGen.sample.getOrElse(defaultHost)
 }

--- a/src/test/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
+++ b/src/test/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
@@ -9,37 +9,36 @@ trait AtlassianHostGen {
 
   def clientKeyGen: Gen[ClientKey] = alphaNumStr
 
-  def pluginVersionGen: Gen[String] =
-    listOfN(3, posNum[Int]).map(n => n.mkString("."))
-
   def productTypeGen: Gen[String] = oneOf("jira", "confluence")
 
   def atlassianHostGen: Gen[DefaultAtlassianHost] =
     for {
       key <- alphaStr
       clientKey <- clientKeyGen
-      publicKey <- alphaNumStr
       oauthClientId <- option(alphaNumStr)
-      sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && !s.isEmpty)
-      serverVersion <- numStr
-      pluginsVersion <- pluginVersionGen
+      sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && s.nonEmpty)
       baseUrl <- alphaStr
       productType <- productTypeGen
       description <- alphaStr
       serviceEntitlementNumber <- option(numStr)
+      entitlementId <- option(numStr)
+      entitlementNumber <- option(numStr)
       installed <- oneOf(true, false)
     } yield
-      DefaultAtlassianHost(clientKey,
-                            key,
-                            publicKey,
-                            oauthClientId,
-                            sharedSecret,
-                            serverVersion,
-                            pluginsVersion,
-                            baseUrl,
-                            productType,
-                            description,
-                            serviceEntitlementNumber,
-                            installed)
+      DefaultAtlassianHost(
+        clientKey,
+        key,
+        oauthClientId,
+        sharedSecret,
+        baseUrl,
+        baseUrl,
+        baseUrl,
+        productType,
+        description,
+        serviceEntitlementNumber,
+        entitlementId,
+        entitlementNumber,
+        installed
+      )
 
 }


### PR DESCRIPTION
- update to `atlassian-connect-play` version 0.5.0 which includes the new model changes
- add the `entitlementNumber` and `entitlementId` fields
- add missing `displayUrl` and `displayUrlServicedeskHelpCenter`
- remove deprecated `publicKey` field
- remove deprecated `serverVersion` and `pluginsVersion` fields
- remove `findByBaseUrl` method from `AtlassianHostRepository`
- update unit, integration tests and generators
- update evolutions file to reflect the model changes