### PR TITLE
Connect on Forge

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
 }
 
 object Version {
-  val atlassianConnectPlay = "0.5.0"
+  val atlassianConnectPlay = "0.6.0"
   val playSlick = "5.1.0"
   val scalaTestPlusPlay = "5.1.0"
   val scalaCheck = "1.14.3"

--- a/src/it/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepositoryIt.scala
+++ b/src/it/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepositoryIt.scala
@@ -96,6 +96,18 @@ class SlickAtlassianHostRepositoryIt
         }
       }
 
+      "find the inserted host by installation id" in new AtlassianHostFixture {
+        withEvolutions {
+          await {
+            hostRepo.save(host)
+          }
+
+          await {
+            hostRepo.findByInstallationId(host.installationId.get)
+          } mustBe Some(host)
+        }
+      }
+
     }
 
     "saving the same Atlassian hosts twice" should {

--- a/src/it/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
+++ b/src/it/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
@@ -8,6 +8,7 @@ trait AtlassianHostFixture extends AtlassianHostGen {
     "a890cfe7-3518-3920-b0b5-6fa412a7f3d4",
     "io.toolsplus.atlassian.connect.play.scala.seed",
     None,
+    Some("ari:cloud:ecosystem::installation/e786c5a3-819e-43cd-9cc9-d38a470a5df6"),
     "LkbauUXN71J8jxRi9Nbf+8dwGtXxqta+Fu6k86aF+0IIzxkZ/GlggElYVoCqQg",
     "https://example.atlassian.net",
     "https://example.atlassian.net",

--- a/src/it/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
+++ b/src/it/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
@@ -16,6 +16,7 @@ trait AtlassianHostGen {
       key <- alphaStr
       clientKey <- clientKeyGen
       oauthClientId <- option(alphaNumStr)
+      installationId <- option(alphaNumStr)
       sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && s.nonEmpty)
       baseUrl <- alphaStr
       productType <- productTypeGen
@@ -29,6 +30,7 @@ trait AtlassianHostGen {
         clientKey,
         key,
         oauthClientId,
+        installationId,
         sharedSecret,
         baseUrl,
         baseUrl,

--- a/src/main/resources/evolutions/default/1.sql
+++ b/src/main/resources/evolutions/default/1.sql
@@ -4,6 +4,7 @@ CREATE TABLE atlassian_host
     client_key                          VARCHAR PRIMARY KEY NOT NULL,
     key                                 VARCHAR             NOT NULL,
     oauth_client_id                     VARCHAR,
+    installation_id                     VARCHAR,
     shared_secret                       VARCHAR             NOT NULL,
     base_url                            VARCHAR             NOT NULL,
     display_url                         VARCHAR             NOT NULL,
@@ -19,6 +20,8 @@ CREATE UNIQUE INDEX uq_ac_host_client_key
     ON atlassian_host (client_key);
 CREATE INDEX uq_ac_host_base_url
     ON atlassian_host (base_url);
+CREATE INDEX uq_ac_host_installation_id
+    ON atlassian_host (installation_id);
 
 # --- !Downs
 DROP TABLE atlassian_host;

--- a/src/main/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepository.scala
+++ b/src/main/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepository.scala
@@ -28,6 +28,9 @@ class SlickAtlassianHostRepository @Inject()(
   def findByClientKey(clientKey: ClientKey): Future[Option[AtlassianHost]] =
     db.run(hosts.filter(_.clientKey === clientKey).result.headOption)
 
+  def findByInstallationId(installationId: String): Future[Option[AtlassianHost]] =
+    db.run(hosts.filter(_.installationId === installationId).result.headOption)
+
   /** Saves the given Atlassian host by inserting it if it does not exist or
     * updating an existing record if it's already present.
     *
@@ -55,6 +58,7 @@ private[slick] trait AtlassianHostTable {
     val clientKey = column[ClientKey]("client_key", O.PrimaryKey)
     val key = column[String]("key", NotNull)
     val oauthClientId = column[Option[String]]("oauth_client_id")
+    val installationId = column[Option[String]]("installation_id")
     val sharedSecret = column[String]("shared_secret", NotNull)
     val baseUrl = column[String]("base_url", NotNull, SqlType("VARCHAR(512)"))
     val displayUrl =
@@ -81,6 +85,7 @@ private[slick] trait AtlassianHostTable {
       (clientKey,
        key,
        oauthClientId,
+       installationId,
        sharedSecret,
        baseUrl,
        displayUrl,
@@ -94,6 +99,7 @@ private[slick] trait AtlassianHostTable {
 
     private def toHost: (ClientKey,
                          String,
+                         Option[String],
                          Option[String],
                          String,
                          String,
@@ -111,6 +117,7 @@ private[slick] trait AtlassianHostTable {
     (ClientKey,
      String,
      Option[String],
+     Option[String],
      String,
      String,
      String,
@@ -126,6 +133,7 @@ private[slick] trait AtlassianHostTable {
         host.clientKey,
         host.key,
         host.oauthClientId,
+        host.installationId,
         host.sharedSecret,
         host.baseUrl,
         host.displayUrl,

--- a/src/test/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepositorySpec.scala
+++ b/src/test/scala/io/toolsplus/atlassian/connect/play/slick/SlickAtlassianHostRepositorySpec.scala
@@ -75,6 +75,18 @@ class SlickAtlassianHostRepositorySpec
           } mustBe Some(host)
         }
       }
+
+      "find the inserted host by installation id" in new AtlassianHostFixture {
+        withEvolutions {
+          await {
+            hostRepo.save(host)
+          }
+
+          await {
+            hostRepo.findByInstallationId(host.installationId.get)
+          } mustBe Some(host)
+        }
+      }
     }
 
     "saving the same Atlassian hosts twice" should {

--- a/src/test/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
+++ b/src/test/scala/io/toolsplus/atlassian/connect/play/slick/fixtures/AtlassianHostFixture.scala
@@ -1,6 +1,6 @@
 package io.toolsplus.atlassian.connect.play.slick.fixtures
 
-import io.toolsplus.atlassian.connect.play.api.models.{AtlassianHost, DefaultAtlassianHost}
+import io.toolsplus.atlassian.connect.play.api.models.DefaultAtlassianHost
 import io.toolsplus.atlassian.connect.play.slick.generators.AtlassianHostGen
 
 trait AtlassianHostFixture extends AtlassianHostGen {
@@ -8,6 +8,7 @@ trait AtlassianHostFixture extends AtlassianHostGen {
     "a890cfe7-3518-3920-b0b5-6fa412a7f3d4",
     "io.toolsplus.atlassian.connect.play.scala.seed",
     None,
+    Some("ari:cloud:ecosystem::installation/e786c5a3-819e-43cd-9cc9-d38a470a5df6"),
     "LkbauUXN71J8jxRi9Nbf+8dwGtXxqta+Fu6k86aF+0IIzxkZ/GlggElYVoCqQg",
     "https://example.atlassian.net",
     "https://example.atlassian.net",

--- a/src/test/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
+++ b/src/test/scala/io/toolsplus/atlassian/connect/play/slick/generators/AtlassianHostGen.scala
@@ -16,6 +16,7 @@ trait AtlassianHostGen {
       key <- alphaStr
       clientKey <- clientKeyGen
       oauthClientId <- option(alphaNumStr)
+      installationId <- option(alphaNumStr)
       sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && s.nonEmpty)
       baseUrl <- alphaStr
       productType <- productTypeGen
@@ -29,6 +30,7 @@ trait AtlassianHostGen {
         clientKey,
         key,
         oauthClientId,
+        installationId,
         sharedSecret,
         baseUrl,
         baseUrl,


### PR DESCRIPTION
- Update atlassian-connect-play to 0.6.0 including the Connect on Forge model changes
- Update the repository implementation to include the optional `installationId` field
- Update tests to account for the installation id field and add new tests to verify find the host by installation id feature

fixes #32